### PR TITLE
Use absolute paths via Path objects

### DIFF
--- a/src/data_preparation/chunk_documents.py
+++ b/src/data_preparation/chunk_documents.py
@@ -1,11 +1,18 @@
 import json
 import re
 import sys
+from pathlib import Path
 from tqdm import tqdm
 
 # Defaults (fallback if not provided as CLI args)
-DEFAULT_INPUT_PATH = "data/processed/combined.jsonl"
-DEFAULT_OUTPUT_PATH = "data/processed/chunked_documents.jsonl"
+DEFAULT_INPUT_PATH = (
+    Path(__file__).resolve().parent.parent.parent
+    / "data/processed/combined.jsonl"
+)
+DEFAULT_OUTPUT_PATH = (
+    Path(__file__).resolve().parent.parent.parent
+    / "data/processed/chunked_documents.jsonl"
+)
 
 CHUNK_SIZE = 1000  # characters
 

--- a/src/data_preparation/chunk_documents_contextual.py
+++ b/src/data_preparation/chunk_documents_contextual.py
@@ -46,10 +46,7 @@ def already_processed_chunks(output_file: Path):
     if not output_file.exists():
         return set()
     with open(output_file, "r", encoding="utf-8") as f:
-        return set(
-            (json.loads(line)["id"], json.loads(line).get("chunk_id", 0))
-            for line in f
-        )
+        return set((json.loads(line)["id"], json.loads(line).get("chunk_id", 0)) for line in f)
 
 def main():
     processed_chunks = already_processed_chunks(OUTPUT_PATH)

--- a/src/data_preparation/chunk_documents_contextual.py
+++ b/src/data_preparation/chunk_documents_contextual.py
@@ -2,11 +2,18 @@ import json
 import os
 import multiprocessing
 import time
+from pathlib import Path
 from tqdm import tqdm
 from ollama import Client
 
-INPUT_PATH = "data/processed/chunked_documents_train.jsonl"
-OUTPUT_PATH = "data/processed/chunked_contextual_train.jsonl"
+INPUT_PATH = (
+    Path(__file__).resolve().parent.parent.parent
+    / "data/processed/chunked_documents_train.jsonl"
+)
+OUTPUT_PATH = (
+    Path(__file__).resolve().parent.parent.parent
+    / "data/processed/chunked_contextual_train.jsonl"
+)
 MODEL_NAME = "gemma3:latest"
 NUM_WORKERS = 8
 
@@ -35,11 +42,14 @@ def process_chunk(line):
     except Exception:
         return None
 
-def already_processed_chunks(output_file):
-    if not os.path.exists(output_file):
+def already_processed_chunks(output_file: Path):
+    if not output_file.exists():
         return set()
     with open(output_file, "r", encoding="utf-8") as f:
-        return set((json.loads(line)["id"], json.loads(line).get("chunk_id", 0)) for line in f)
+        return set(
+            (json.loads(line)["id"], json.loads(line).get("chunk_id", 0))
+            for line in f
+        )
 
 def main():
     processed_chunks = already_processed_chunks(OUTPUT_PATH)

--- a/src/data_preparation/generate_eval_questions.py
+++ b/src/data_preparation/generate_eval_questions.py
@@ -1,8 +1,15 @@
 import json
 from collections import defaultdict
+from pathlib import Path
 
-EVAL_CHUNKED = "data/processed/chunked_documents_eval.jsonl"
-EVAL_OUTPUT = "data/processed/eval_questions.jsonl"
+EVAL_CHUNKED = (
+    Path(__file__).resolve().parent.parent.parent
+    / "data/processed/chunked_documents_eval.jsonl"
+)
+EVAL_OUTPUT = (
+    Path(__file__).resolve().parent.parent.parent
+    / "data/processed/eval_questions.jsonl"
+)
 
 # Group chunks by question ID
 by_question = defaultdict(list)

--- a/src/data_preparation/split_questions_before_chunking.py
+++ b/src/data_preparation/split_questions_before_chunking.py
@@ -1,9 +1,19 @@
 import json
 import random
+from pathlib import Path
 
-INPUT = "data/processed/combined.jsonl"
-TRAIN_OUT = "data/processed/train_questions.jsonl"
-EVAL_OUT = "data/processed/eval_questions_raw.jsonl"
+INPUT = (
+    Path(__file__).resolve().parent.parent.parent
+    / "data/processed/combined.jsonl"
+)
+TRAIN_OUT = (
+    Path(__file__).resolve().parent.parent.parent
+    / "data/processed/train_questions.jsonl"
+)
+EVAL_OUT = (
+    Path(__file__).resolve().parent.parent.parent
+    / "data/processed/eval_questions_raw.jsonl"
+)
 
 random.seed(42)
 

--- a/src/retrieval/contextual_retriever.py
+++ b/src/retrieval/contextual_retriever.py
@@ -2,13 +2,23 @@
 
 import json
 import os
+from pathlib import Path
 import faiss
 import numpy as np
 from sentence_transformers import SentenceTransformer
 
-INPUT_PATH = 'data/processed/chunked_contextual.jsonl'
-INDEX_PATH = 'data/processed/faiss_contextual.index'
-DOCS_PATH = 'data/processed/contextual_docs.jsonl'
+INPUT_PATH = (
+    Path(__file__).resolve().parent.parent.parent
+    / "data/processed/chunked_contextual.jsonl"
+)
+INDEX_PATH = (
+    Path(__file__).resolve().parent.parent.parent
+    / "data/processed/faiss_contextual.index"
+)
+DOCS_PATH = (
+    Path(__file__).resolve().parent.parent.parent
+    / "data/processed/contextual_docs.jsonl"
+)
 
 EMBED_MODEL_NAME = 'sentence-transformers/all-MiniLM-L6-v2'
 
@@ -42,8 +52,8 @@ def main():
     print("Building FAISS index...")
     index = build_index(embeddings)
 
-    os.makedirs(os.path.dirname(INDEX_PATH), exist_ok=True)
-    faiss.write_index(index, INDEX_PATH)
+    INDEX_PATH.parent.mkdir(parents=True, exist_ok=True)
+    faiss.write_index(index, str(INDEX_PATH))
 
     with open(DOCS_PATH, 'w', encoding='utf-8') as f:
         for entry in metadata:

--- a/src/retrieval/query_rag.py
+++ b/src/retrieval/query_rag.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+from pathlib import Path
 
 # Add project root to Python path
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
@@ -15,8 +16,14 @@ import numpy as np
 from sentence_transformers import SentenceTransformer
 from src.generation.generate_answers import generate_answer
 
-INDEX_PATH = 'data/processed/faiss_rag.index'
-DOCS_PATH = 'data/processed/rag_docs.jsonl'
+INDEX_PATH = (
+    Path(__file__).resolve().parent.parent.parent
+    / "data/processed/faiss_rag.index"
+)
+DOCS_PATH = (
+    Path(__file__).resolve().parent.parent.parent
+    / "data/processed/rag_docs.jsonl"
+)
 EMBED_MODEL_NAME = 'sentence-transformers/all-MiniLM-L6-v2'
 TOP_K = 10
 OLLAMA_MODEL = "gemma3:latest"  # Or change to llama3.2:latest if needed
@@ -34,7 +41,7 @@ def search_index(query, model, index, docs, k=TOP_K):
 def main():
     print("Loading index and model...")
     model = SentenceTransformer(EMBED_MODEL_NAME)
-    index = faiss.read_index(INDEX_PATH)
+    index = faiss.read_index(str(INDEX_PATH))
     docs = load_documents(DOCS_PATH)
 
     while True:

--- a/src/retrieval/rag_retriever.py
+++ b/src/retrieval/rag_retriever.py
@@ -2,13 +2,23 @@
 
 import json
 import os
+from pathlib import Path
 import faiss
 import numpy as np
 from sentence_transformers import SentenceTransformer
 
-INPUT_PATH = "data/processed/chunked_documents_train.jsonl"
-INDEX_PATH = 'data/processed/faiss_rag.index'
-DOCS_PATH = 'data/processed/rag_docs.jsonl'
+INPUT_PATH = (
+    Path(__file__).resolve().parent.parent.parent
+    / "data/processed/chunked_documents_train.jsonl"
+)
+INDEX_PATH = (
+    Path(__file__).resolve().parent.parent.parent
+    / "data/processed/faiss_rag.index"
+)
+DOCS_PATH = (
+    Path(__file__).resolve().parent.parent.parent
+    / "data/processed/rag_docs.jsonl"
+)
 
 EMBED_MODEL_NAME = 'sentence-transformers/all-MiniLM-L6-v2'
 
@@ -43,8 +53,8 @@ def main():
     print("Building FAISS index...")
     index = build_index(embeddings)
 
-    os.makedirs(os.path.dirname(INDEX_PATH), exist_ok=True)
-    faiss.write_index(index, INDEX_PATH)
+    INDEX_PATH.parent.mkdir(parents=True, exist_ok=True)
+    faiss.write_index(index, str(INDEX_PATH))
 
     with open(DOCS_PATH, 'w', encoding='utf-8') as f:
         for entry in metadata:

--- a/src/retrieval/rag_retriever.py
+++ b/src/retrieval/rag_retriever.py
@@ -7,18 +7,10 @@ import faiss
 import numpy as np
 from sentence_transformers import SentenceTransformer
 
-INPUT_PATH = (
-    Path(__file__).resolve().parent.parent.parent
-    / "data/processed/chunked_documents_train.jsonl"
-)
-INDEX_PATH = (
-    Path(__file__).resolve().parent.parent.parent
-    / "data/processed/faiss_rag.index"
-)
-DOCS_PATH = (
-    Path(__file__).resolve().parent.parent.parent
-    / "data/processed/rag_docs.jsonl"
-)
+BASE_PATH = Path(__file__).resolve().parent.parent.parent
+INPUT_PATH = BASE_PATH / "data/processed/chunked_documents_train.jsonl"
+INDEX_PATH = BASE_PATH / "data/processed/faiss_rag.index"
+DOCS_PATH = BASE_PATH / "data/processed/rag_docs.jsonl"
 
 EMBED_MODEL_NAME = 'sentence-transformers/all-MiniLM-L6-v2'
 


### PR DESCRIPTION
## Summary
- load data files using `Path(__file__)` so scripts work from any path
- update retrieval scripts
- update data preparation utilities

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sentence_transformers')*

------
https://chatgpt.com/codex/tasks/task_e_687b0cb060f48329b261b3c696ee0029