### PR TITLE
Remove unused numpy imports

### DIFF
--- a/src/evaluation/eval_contextual_all.py
+++ b/src/evaluation/eval_contextual_all.py
@@ -1,6 +1,5 @@
 import json
 import faiss
-import numpy as np
 from sentence_transformers import SentenceTransformer
 from tqdm import tqdm
 

--- a/src/evaluation/eval_rag_all.py
+++ b/src/evaluation/eval_rag_all.py
@@ -1,6 +1,5 @@
 import json
 import faiss
-import numpy as np
 from sentence_transformers import SentenceTransformer
 from tqdm import tqdm
 

--- a/src/retrieval/contextual_retriever.py
+++ b/src/retrieval/contextual_retriever.py
@@ -4,7 +4,6 @@ import json
 import os
 from pathlib import Path
 import faiss
-import numpy as np
 from sentence_transformers import SentenceTransformer
 
 INPUT_PATH = (

--- a/src/retrieval/rag_retriever.py
+++ b/src/retrieval/rag_retriever.py
@@ -4,7 +4,6 @@ import json
 import os
 from pathlib import Path
 import faiss
-import numpy as np
 from sentence_transformers import SentenceTransformer
 
 BASE_PATH = Path(__file__).resolve().parent.parent.parent

--- a/test_contextual.py
+++ b/test_contextual.py
@@ -1,7 +1,6 @@
 from sentence_transformers import SentenceTransformer
 import faiss
 import json
-import numpy as np
 
 INDEX_PATH = 'data/processed/faiss_contextual.index'
 DOCS_PATH = 'data/processed/contextual_docs.jsonl'

--- a/test_rag.py
+++ b/test_rag.py
@@ -1,7 +1,6 @@
 from sentence_transformers import SentenceTransformer
 import faiss
 import json
-import numpy as np
 
 INDEX_PATH = 'data/processed/faiss_rag.index'
 DOCS_PATH = 'data/processed/rag_docs.jsonl'


### PR DESCRIPTION
## Summary
- clean up unused `numpy` imports in retrieval and evaluation scripts
- ensure compilation with `py_compile`

## Testing
- `python -m py_compile src/retrieval/rag_retriever.py src/retrieval/contextual_retriever.py src/evaluation/eval_rag_all.py src/evaluation/eval_contextual_all.py test_rag.py test_contextual.py`

------
https://chatgpt.com/codex/tasks/task_e_687b1a0615e4832991d53034300632bc