### PR TITLE
Add processed data README and update main docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,14 @@ Prototype comparing Retrieval-Augmented Generation and Contextual Retrieval for 
 ## License
 
 This project is licensed under the [MIT License](LICENSE).
+
+## Generating retrieval indexes
+The FAISS index and metadata files used by the tests are not committed to Git. Generate them by running:
+
+```bash
+python src/retrieval/rag_retriever.py
+python src/retrieval/contextual_retriever.py
+```
+
+This will produce the `.index` and `.jsonl` files inside `data/processed/`.
+

--- a/data/processed/README.md
+++ b/data/processed/README.md
@@ -9,3 +9,7 @@ python src/retrieval/contextual_retriever.py
 
 The scripts will create `faiss_rag.index`, `faiss_contextual.index`, `rag_docs.jsonl`, and `contextual_docs.jsonl`.
 
+- `faiss_rag.index`: Contains the vector embeddings for retrieval-augmented generation (RAG) retrieval.
+- `faiss_contextual.index`: Contains the vector embeddings for contextual retrieval.
+- `rag_docs.jsonl`: Stores metadata and chunked text data for documents used in RAG retrieval.
+- `contextual_docs.jsonl`: Stores metadata and chunked text data for documents used in contextual retrieval.

--- a/data/processed/README.md
+++ b/data/processed/README.md
@@ -1,0 +1,11 @@
+This directory holds generated retrieval artifacts.
+Large FAISS indexes and the JSONL files describing document chunks are not stored in the repository.
+Run the retriever scripts to populate this folder:
+
+```
+python src/retrieval/rag_retriever.py
+python src/retrieval/contextual_retriever.py
+```
+
+The scripts will create `faiss_rag.index`, `faiss_contextual.index`, `rag_docs.jsonl`, and `contextual_docs.jsonl`.
+


### PR DESCRIPTION
## Summary
- document how to create FAISS indexes and chunk metadata
- add `data/processed/README.md` placeholder explaining generated artifacts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sentence_transformers')*

------
https://chatgpt.com/codex/tasks/task_e_687b1b2517948329b429ca4d63a8bea5